### PR TITLE
Compile under 1.4.0 nightly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+Cargo.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,3 @@
 language: rust
 rust:
-  - stable
-  - beta
   - nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: rust
-script:
-  - cargo build
-  - cargo test
+rust:
+  - stable
+  - beta
+  - nightly


### PR DESCRIPTION
As @milgner noticed this is broken with the latest Rust nightly build. This makes everything compile again. And even though the tests pass I don't really know if the functionality has changed or not.

It is now broken under the current stable version, but due to the usage of `#![feature(...)]` it couldn't be compiled with the stable compiler anyway.